### PR TITLE
TFTP container logging and proper support for external mysql and rabbitmq services

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: openstack-ironic-standalone
-version: 0.2.0
+version: 0.2.1
 appVersion: rocky
 description: Openstack Ironic chart for Kubernetes
 home: https://docs.openstack.org/ironic/latest/

--- a/templates/mysql-secret.yaml
+++ b/templates/mysql-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.mysql.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $.Release.Name }}-mysql
+  labels:
+    app.kubernetes.io/name: {{ include "openstackIronicStandalone.name" $ }}
+    helm.sh/chart: {{ include "openstackIronicStandalone.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+data:
+  mysql-password: {{ $.Values.mysql.mysqlPassword }}
+  mysql-root-password: {{ $.Values.mysql.mysqlRootPassword }}
+{{- end -}}

--- a/templates/rabbitmq-secret.yaml
+++ b/templates/rabbitmq-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.rabbitmq.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $.Release.Name }}-rabbitmq
+  labels:
+    app.kubernetes.io/name: {{ include "openstackIronicStandalone.name" $ }}
+    helm.sh/chart: {{ include "openstackIronicStandalone.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+data:
+  rabbitmq-password: {{ $.Values.rabbitmq.rabbitmq.password }}
+  rabbitmq-erlang-cookie: {{ $.Values.rabbitmq.rabbitmq.erlangCookie }}
+{{- end -}}

--- a/templates/tftp-daemonset.yaml
+++ b/templates/tftp-daemonset.yaml
@@ -35,13 +35,10 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           tty: true
           command: 
-          - /usr/sbin/in.tftpd
-          - --ipv4
-          - -v
-          - --foreground
-          - --map-file
-          - /etc/tftp-map-file
-          - /tftpboot
+            - /bin/sh
+          args:
+            - -c
+            - rsyslogd -n & /usr/sbin/in.tftpd --ipv4 -v --foreground --map-file /etc/tftp-map-file /tftpboot
           volumeMounts:
             - mountPath: /tftpboot
               name: ironic
@@ -50,9 +47,6 @@ spec:
               name: ironic-etc
               subPath: tftp-map-file
               readOnly: true
-            - mountPath: /dev/log
-              name: devlog
-              readOnly: false
         {{- with .Values.tftp.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -69,6 +63,3 @@ spec:
           configMap:
             name: {{ include "openstackIronicStandalone.name" . }}-etc
             defaultMode: 0644
-        - name: devlog
-          hostPath:
-            path: /dev/log

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ ironicServerName: DEFINE-SERVER-NAME.IO
 ##
 image:
   name: jakubdlu/centos-openstack-ironic
-  version: rocky-0.0.9
+  version: rocky-0.0.10
   pullPolicy: IfNotPresent
 
 ## Existing persistent volume claim

--- a/values.yaml
+++ b/values.yaml
@@ -229,6 +229,7 @@ rabbitmq:
   rabbitmq:
     username: rabbitmq
 #    password: DEFINE-THIS-SECRET
+#    erlangCookie: DEFINE-THIS-SECRET
   image:
     pullPolicy: IfNotPresent
   persistence:


### PR DESCRIPTION
Log tftpd to stdout. 
Create secrets for external mysql and rabbitmq services. Needed for ironic configfile generator.
Please test with pre-defined PVC before releasing the change.