### PR TITLE
Tftpd revamp

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: openstack-ironic-standalone
-version: 0.2.0
+version: 0.2.1
 appVersion: rocky
 description: Openstack Ironic chart for Kubernetes
 home: https://docs.openstack.org/ironic/latest/

--- a/README.md
+++ b/README.md
@@ -116,3 +116,6 @@ That's why we start in.tftpd DaemonSet with hostNetwork enabled.
 It means that we have a pool of servers running in.tftpd.
 Only the one that has the external IP address attached will be serving files.
 It does not use a Kubernetes network model (POD network, service network).
+
+The tftpd service can be exposed using keepalived floating IP, simple DNS
+round-robin record or simply by aiming directly at k8s node address.

--- a/static-config/httpd.conf
+++ b/static-config/httpd.conf
@@ -1,0 +1,27 @@
+user nginx;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+        worker_connections 1024;
+}
+
+http {
+        sendfile off;
+        tcp_nopush on;
+        tcp_nodelay on;
+        send_timeout 7200;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+        access_log /dev/stdout;
+        error_log /dev/stdout info;
+        gzip off;
+        server {
+                listen 6969 default_server;
+                root /usr/share/nginx/html;
+                autoindex on;
+                server_name httpd;
+        }
+}

--- a/templates/etc/_ironic.conf.tpl
+++ b/templates/etc/_ironic.conf.tpl
@@ -15,7 +15,7 @@ port = {{ $.Values.api.portInternal }}
 {{- if $.Values.api.ingress.enabled }}
 api_url = http://{{ $.Values.api.ingress.hosts | first }}/
 {{- else }}
-api_url = http://{{ include "openstackIronicStandalone.api.fullname" $ }}:{{ $.Values.api.portExternal }}/
+api_url = http://{{ $.Values.api.externalIPs | first }}:{{ $.Values.api.portExternal }}/
 {{- end }}
 {{- end }}
 {{- if eq $section "database" }}
@@ -27,7 +27,7 @@ connection = mysql+pymysql://{{ default "root" $.Values.mysql.mysqlUser }}:${os.
 {{- if $.Values.httpboot.ingress.enabled }}
 http_url = http://{{ $.Values.httpboot.ingress.hosts | first }}/
 {{- else }}
-http_url = http://{{ include "openstackIronicStandalone.httpboot.fullname" $ }}/
+http_url = http://{{ $.Values.httpboot.externalIPs | first }}/
 {{- end }}
 {{- end }}
 {{- if eq $section "pxe" }}

--- a/templates/httpboot-deployment.yaml
+++ b/templates/httpboot-deployment.yaml
@@ -45,6 +45,7 @@ spec:
             - "/usr/share/syslinux/pxelinux.0"
             - "/usr/share/ipxe/ipxe.efi"
             - "/usr/share/syslinux/custom-ipxe.efi"
+            - "/usr/share/syslinux/custom-undionly.kpxe"
             - "/tftpboot/"
           securityContext:
             runAsUser: 0

--- a/templates/mgmt-node-deployment.yaml
+++ b/templates/mgmt-node-deployment.yaml
@@ -32,17 +32,9 @@ spec:
           - name: IRONIC_API_VERSION
             value: latest
           - name: IRONIC_URL
-            {{- if .Values.api.ingress.enabled }}
-            value: "http://{{ .Values.api.ingress.hosts | first }}/"
-            {{- else }}
             value: "http://{{ include "openstackIronicStandalone.api.fullname" . }}:{{ .Values.api.portExternal }}/"
-            {{- end }}
           - name: OS_URL
-            {{- if .Values.api.ingress.enabled }}
-            value: "http://{{ .Values.api.ingress.hosts | first }}/"
-            {{- else }}
             value: "http://{{ include "openstackIronicStandalone.api.fullname" . }}:{{ .Values.api.portExternal }}/"
-            {{- end }}
           - name: OS_TOKEN
             value: "fake-token"
           - name: OS_AUTH_TOKEN

--- a/templates/mysql-secret.yaml
+++ b/templates/mysql-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.mysql.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $.Release.Name }}-mysql
+  labels:
+    app.kubernetes.io/name: {{ include "openstackIronicStandalone.name" $ }}
+    helm.sh/chart: {{ include "openstackIronicStandalone.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+data:
+  mysql-password: {{ $.Values.mysql.mysqlPassword }}
+  mysql-root-password: {{ $.Values.mysql.mysqlRootPassword }}
+{{- end -}}

--- a/templates/rabbitmq-secret.yaml
+++ b/templates/rabbitmq-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.rabbitmq.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $.Release.Name }}-rabbitmq
+  labels:
+    app.kubernetes.io/name: {{ include "openstackIronicStandalone.name" $ }}
+    helm.sh/chart: {{ include "openstackIronicStandalone.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+data:
+  rabbitmq-password: {{ $.Values.rabbitmq.rabbitmq.password }}
+  rabbitmq-erlang-cookie: {{ $.Values.rabbitmq.rabbitmq.erlangCookie }}
+{{- end -}}

--- a/templates/tftp-daemonset.yaml
+++ b/templates/tftp-daemonset.yaml
@@ -35,13 +35,10 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           tty: true
           command: 
-          - /usr/sbin/in.tftpd
-          - --ipv4
-          - -v
-          - --foreground
-          - --map-file
-          - /etc/tftp-map-file
-          - /tftpboot
+            - /bin/sh
+          args:
+            - -c
+            - rsyslogd -n & /usr/sbin/in.tftpd --ipv4 -v --foreground --map-file /etc/tftp-map-file /tftpboot
           volumeMounts:
             - mountPath: /tftpboot
               name: ironic
@@ -50,9 +47,6 @@ spec:
               name: ironic-etc
               subPath: tftp-map-file
               readOnly: true
-            - mountPath: /dev/log
-              name: devlog
-              readOnly: false
         {{- with .Values.tftp.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -69,6 +63,3 @@ spec:
           configMap:
             name: {{ include "openstackIronicStandalone.name" . }}-etc
             defaultMode: 0644
-        - name: devlog
-          hostPath:
-            path: /dev/log

--- a/templates/tftp-daemonset.yaml
+++ b/templates/tftp-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       containers:
-        - name: {{ include "openstackIronicStandalone.tftp.fullname" . }}
+        - name: tftpd
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           tty: true
@@ -51,6 +51,23 @@ spec:
           resources:
 {{ toYaml . | indent 12 }}
         {{- end }}
+        - name: httpd
+          image:  "{{ .Values.httpboot.image.name }}:{{ .Values.httpboot.image.version }}"
+          volumeMounts:
+            - mountPath: /etc/nginx/nginx.conf
+              name: ironic-etc
+              subPath: httpd.conf
+              readOnly: true
+            - mountPath: /usr/share/nginx/html
+              name: ironic
+              {{- if .Values.config.pxe.ipxe_enabled }}
+              subPath: httpboot
+              {{- else }}
+              subPath: tftpboot
+              {{- end }}
+            - mountPath: /usr/share/nginx/html/boot.ipxe
+              name: ironic-etc
+              subPath: boot.ipxe
       volumes:
         - name: ironic
           persistentVolumeClaim:

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ ironicServerName: DEFINE-SERVER-NAME.IO
 ##
 image:
   name: jakubdlu/centos-openstack-ironic
-  version: rocky-0.0.9
+  version: rocky-0.0.10
   pullPolicy: IfNotPresent
 
 ## Existing persistent volume claim

--- a/values.yaml
+++ b/values.yaml
@@ -229,6 +229,7 @@ rabbitmq:
   rabbitmq:
     username: rabbitmq
 #    password: DEFINE-THIS-SECRET
+#    erlangCookie: DEFINE-THIS-SECRET
   image:
     pullPolicy: IfNotPresent
   persistence:

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ ironicServerName: DEFINE-SERVER-NAME.IO
 ##
 image:
   name: jakubdlu/centos-openstack-ironic
-  version: rocky-0.0.10
+  version: rocky-0.0.12
   pullPolicy: IfNotPresent
 
 ## Existing persistent volume claim
@@ -46,7 +46,7 @@ config:
     tftp_master_path: /storage/tftpboot/master-path
     pxe_append_params: "console=tty0 console=ttyS0,115200 coreos.autologin=tty0"
     ipxe_boot_script: $pybasedir/drivers/modules/boot.ipxe
-    ## to enable ipxe, replace values of both following keys
+    ## to enable/disable ipxe, replace values of both following keys
     ipxe_enabled: false
     pxe_config_template: $pybasedir/drivers/modules/pxe_config.template
     # ipxe_enabled: true


### PR DESCRIPTION
* Log tftpd daemonset containers to stdout/k8s
* Add nginx container to tftpd daemonset for transparent iPXE operations (requires jakubdlu/centos-openstack-ironic:rocky-0.0.12 or newer)
* Fix management pod environment variables
* Store mysql and rabbitmq auth data in k8s secrets
